### PR TITLE
chore: fix loaders.py bugs; add reproducibility tests and pyproject.toml

### DIFF
--- a/notebooks/eta/eda_make_friedman1.ipynb
+++ b/notebooks/eta/eda_make_friedman1.ipynb
@@ -1,8 +1,64 @@
 {
- "cells": [],
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fd9b8e28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import make_friedman3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a81e286e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X, y = make_friedman3(n_samples=100, noise=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a8b19c57",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(100, 4)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X.shape"
+   ]
+  }
+ ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "repo-3.12-bagging-boosting-stacking-study",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+# pyproject.toml
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bagging-boosting-stacking-study"
+version = "0.1.0"
+description = "Comparative study of bagging, boosting, and stacking methods on synthetic and real datasets"
+readme = "README.md"
+requires-python = ">=3.12,<4.0"
+authors = [
+  { name = "Szymon Pawlowski", email = "szy.pawlo@gmail.com" },
+]
+
+dependencies = [
+  "numpy>=2.2,<3.0",
+  "pandas>=2.2,<3.0",
+  "scikit-learn>=1.6,<2.0",
+  "scipy>=1.15,<2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0,<8.0",
+  "flake8>=6.0,<7.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+exclude = ["tests*"]

--- a/src/data/loaders.py
+++ b/src/data/loaders.py
@@ -7,54 +7,60 @@ from sklearn.datasets import (
 )
 
 # Global Vars
-ROOT_PATH = pathlib.Path(__file__).resolve().parents[2]      # project-root
+ROOT_PATH = pathlib.Path(__file__).resolve().parents[2]  # project-root
 RAW_DATA_PATH = ROOT_PATH / "data" / "raw"
 SEED = 333
+GENERATORS_CONFIG = {
+    "regression": dict(n_samples=1000, n_features=10, n_informative=8, noise=3),
+    "friedman1": dict(n_samples=5000, n_features=20, noise=0.5),
+    "friedman3": dict(n_samples=200, noise=0.3),
+}
+
+
+def _assemble_df(
+    X, y, feature_prefix: str = "feature", target_name: str = "target"
+) -> pd.DataFrame:
+    """Helper function for DataFrame assembly."""
+    df = pd.DataFrame(X, columns=[f"{feature_prefix}_{i}" for i in range(X.shape[1])])
+    df[target_name] = y
+    return df
+
 
 def _generate_regression_dataset() -> pd.DataFrame:
-    """Generate a toy regression dataset using sklearn."""
-    X, y = make_regression(n_samples = 1000, n_features = 20, n_informative = 5, noise = 30, random_state = SEED)
+    """Generate a regression dataset using sklearn `make_regression`."""
+    params = GENERATORS_CONFIG["regression"]
+    X, y = make_regression(random_state=SEED, **params)
+    return _assemble_df(X=X, y=y)
 
-    X_df = pd.DataFrame(X, columns=[f'feature_{i}' for i in range(X.shape[1])])
-    y_df = pd.DataFrame(y, columns=['traget'])
-
-    df = pd.concat([X_df, y_df], axis=1)
-
-    return df
 
 def _generate_friedman1_dataset() -> pd.DataFrame:
     """Generate a Friedman #1 regression dataset."""
-    X, y = make_friedman1(n_samples = 500, noise = 0.5, random_state = SEED)
+    params = GENERATORS_CONFIG["friedman1"]
+    X, y = make_friedman1(random_state=SEED, **params)
+    return _assemble_df(X=X, y=y)
 
-    X_df = pd.DataFrame(X, columns=[f'feature_{i}' for i in range(X.shape[1])])
-    y_df = pd.DataFrame(y, columns=['traget'])
-
-    df = pd.concat([X_df, y_df], axis=1)
-
-    return df
 
 def _generate_friedman3_dataset() -> pd.DataFrame:
     """Generate a Friedman #3 regression dataset."""
-    X, y = make_friedman3(n_samples = 2000, noise = 1.0, random_state = SEED)
+    params = GENERATORS_CONFIG["friedman3"]
+    X, y = make_friedman3(random_state=SEED, **params)
+    return _assemble_df(X=X, y=y)
 
-    X_df = pd.DataFrame(X, columns=[f'feature_{i}' for i in range(X.shape[1])])
-    y_df = pd.DataFrame(y, columns=['traget'])
-
-    df = pd.concat([X_df, y_df], axis=1)
-
-    return df
 
 def _get_california_housing_dataset() -> pd.DataFrame:
     """Load the California housing CSV from raw data."""
-    return pd.read_csv(RAW_DATA_PATH / 'california_housing.csv')
+    return pd.read_csv(RAW_DATA_PATH / "california_housing.csv")
 
-def _get_airfloil_self_noise_dataset() -> pd.DataFrame:
+
+def _get_airfoil_self_noise_dataset() -> pd.DataFrame:
     """Load the Airfoil Self-Noise CSV from raw data."""
-    return pd.read_csv(RAW_DATA_PATH / 'airfoil_self_noise.csv')
+    return pd.read_csv(RAW_DATA_PATH / "airfoil_self_noise.csv")
+
 
 def _get_energy_efficiency_dataset() -> pd.DataFrame:
     """Load the Energy Efficiency CSV from raw data."""
-    return pd.read_csv(RAW_DATA_PATH / 'energy_efficiency.csv')
+    return pd.read_csv(RAW_DATA_PATH / "energy_efficiency.csv")
+
 
 def load_dataset(dataset_name: str) -> pd.DataFrame:
     if not isinstance(dataset_name, str):
@@ -83,7 +89,7 @@ def load_dataset(dataset_name: str) -> pd.DataFrame:
         "friedman1": _generate_friedman1_dataset,
         "friedman3": _generate_friedman3_dataset,
         "california_housing": _get_california_housing_dataset,
-        "airfoil_self_noise": _get_airfloil_self_noise_dataset,
+        "airfoil_self_noise": _get_airfoil_self_noise_dataset,
         "energy_efficiency": _get_energy_efficiency_dataset,
     }
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,60 @@
+import pytest
+import pandas as pd
+from src.data import loaders
+
+
+# Config immutability ------------------------------------------------------------------
+def test_generators_config_immutable():
+    expected = {
+        "regression": {
+            "n_samples": 1000,
+            "n_features": 10,
+            "n_informative": 8,
+            "noise": 3,
+        },
+        "friedman1": {"n_samples": 5000, "n_features": 20, "noise": 0.5},
+        "friedman3": {"n_samples": 200, "noise": 0.3},
+    }
+    assert loaders.GENERATORS_CONFIG == expected
+
+
+# Synthetic generators reproducibility -------------------------------------------------
+def test_regression_reproducible():
+    df1 = loaders._generate_regression_dataset()
+    df2 = loaders._generate_regression_dataset()
+    pd.testing.assert_frame_equal(df1, df2)
+
+
+def test_friedman1_reproducible():
+    df1 = loaders._generate_friedman1_dataset()
+    df2 = loaders._generate_friedman1_dataset()
+    pd.testing.assert_frame_equal(df1, df2)
+
+
+def test_friedman3_reproducible():
+    df1 = loaders._generate_friedman3_dataset()
+    df2 = loaders._generate_friedman3_dataset()
+    pd.testing.assert_frame_equal(df1, df2)
+
+
+# Synthetic shape & seed‐stability -----------------------------------------------------
+@pytest.mark.parametrize("name", ["regression", "friedman1"])
+def test_synthetic_shape_matches_config(name):
+    cfg = loaders.GENERATORS_CONFIG[name]
+    # call the internal generator
+    gen = getattr(loaders, f"_generate_{name}_dataset")
+    df = gen()
+    # rows should equal n_samples
+    assert df.shape[0] == cfg["n_samples"]
+    # cols should equal n_features + target
+    assert df.shape[1] == cfg["n_features"] + 1
+
+
+def test_friedman3_shape_and_seed():
+    # friedman3 has no n_features key; by default make_friedman3 => 4 features
+    df1 = loaders._generate_friedman3_dataset()
+    df2 = loaders._generate_friedman3_dataset()
+    # reproducible
+    pd.testing.assert_frame_equal(df1, df2)
+    # correct shape: 200 rows, 4 features + 1 target = 5 cols
+    assert df1.shape == (loaders.GENERATORS_CONFIG["friedman3"]["n_samples"], 5)


### PR DESCRIPTION
- Correct parameter unpacking in _generate_* functions (use **params)
- Remove unsupported n_features from friedman3 config
- Add tests/test_loaders.py verifying: • GENERATORS_CONFIG is immutable • synthetic generators produce identical outputs on repeated calls
- Add pyproject.toml for project metadata, dependencies, and editable install